### PR TITLE
Push image to Dockerhub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,73 @@ on:
     branches: [ "main" ]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.6
+
+      - name: Load cached poetry
+        id: cached-poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.local
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install and configure Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root --with dev
+
+      - name: Run tests
+        run: bash -c scripts/test.sh
+
+  create_infrastructure:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set up terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.7.5
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::246770851643:role/github-actions
+          aws-region: eu-central-1
+
+      - name: Create infrastructure
+        run: |
+          cd terraform
+          terraform init
+          terraform apply -auto-approve
+
   build_docker_multi_arch:
+    needs: create_infrastructure
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         run: poetry export -f requirements.txt -o requirements.txt --without-hashes
 
       - name: Docker meta
-        id: meta
+        id: meta-dockerhub
         uses: docker/metadata-action@v5
         with:
           images: tobiaswaslowski/mood-tracker
@@ -85,18 +85,42 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
+      - name: Docker meta
+        id: meta-ecr
+        uses: docker/metadata-action@v5
+        with:
+          images: public.ecr.aws/c1o1h8f4/mood-tracker
+          flavor: |
+            latest=true
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-dockerhub.outputs.tags }}
+          labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Push to Amazon ECR
-        run: |
-          docker tag tobiaswaslowski/mood-tracker:${{ steps.meta.outputs.version }} ${{ steps.login-ecr.outputs.registry }}:latest
-          docker push ${{ steps.login-ecr.outputs.registry }}:latest
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-ecr.outputs.tags }}
+          labels: ${{ steps.meta-ecr.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,12 +87,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::246770851643:role/github-actions
-          aws-region: us-east-1
-
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -104,12 +98,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          registry-type: 'public'
-          mask-password: 'true'
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Load cached poetry
         id: cached-poetry
@@ -134,7 +127,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: public.ecr.aws/c1o1h8f4/mood-tracker
+          images: tobiaswaslowski/mood-tracker
           flavor: |
             latest=true
           # generate Docker tags based on the following events/attributes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,11 +97,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::246770851643:role/github-actions
+          aws-region: us-east-1
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Load cached poetry
         id: cached-poetry
@@ -120,7 +130,6 @@ jobs:
 
       - name: export requirements
         run: poetry export -f requirements.txt -o requirements.txt --without-hashes
-
 
       - name: Docker meta
         id: meta
@@ -149,3 +158,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Push to Amazon ECR
+        run: |
+          docker tag tobiaswaslowski/mood-tracker:latest ${{ steps.login-ecr.outputs.registry }}:latest
+          docker push ${{ steps.login-ecr.outputs.registry }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,71 +14,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.11
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.6
-
-      - name: Load cached poetry
-        id: cached-poetry
-        uses: actions/cache@v4
-        with:
-          path: ~/.local
-          key: dotlocal-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install and configure Poetry
-        if: steps.cached-poetry.outputs.cache-hit != 'true'
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root --with dev
-
-      - name: Run tests
-        run: bash -c scripts/test.sh
-
-  create_infrastructure:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: set up terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.7.5
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::246770851643:role/github-actions
-          aws-region: eu-central-1
-
-      - name: Create infrastructure
-        run: |
-          cd terraform
-          terraform init
-          terraform apply -auto-approve
-
   build_docker_multi_arch:
     needs: create_infrastructure
     runs-on: ubuntu-latest
@@ -112,6 +47,9 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: 'public'
+          mask-password: 'true'
 
       - name: Load cached poetry
         id: cached-poetry
@@ -161,5 +99,5 @@ jobs:
 
       - name: Push to Amazon ECR
         run: |
-          docker tag tobiaswaslowski/mood-tracker:latest ${{ steps.login-ecr.outputs.registry }}:latest
+          docker tag tobiaswaslowski/mood-tracker:${{ steps.meta.outputs.version }} ${{ steps.login-ecr.outputs.registry }}:latest
           docker push ${{ steps.login-ecr.outputs.registry }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,6 @@ jobs:
   build_docker_multi_arch:
     needs: create_infrastructure
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   build_docker_multi_arch:
-    needs: create_infrastructure
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Assuming you have a MongoDB instance running on your local machine that is bound
 (e.g. by running `docker run -p 27017:27017 mongo`) you can run the following command:
 
     docker run --env TELEGRAM_TOKEN=$TELEGRAM_TOKEN \
-      public.ecr.aws/c1o1h8f4/mood-tracker:latest
+      tobiaswaslowski/mood-tracker:latest
 
 Supported architectures are x86_64 (amd64) and arm64. If you require images
 for additional architectures, feel free to raise a ticket or build your own images (see [Development](#development)).
@@ -97,7 +97,7 @@ The run command in that case could look like this:
     docker run --env TELEGRAM_TOKEN=$TELEGRAM_TOKEN \
         --env MONGO_HOST=192.168.1.1:27017 \
         --network="host" \
-          public.ecr.aws/c1o1h8f4/mood-tracker:latest
+          tobiaswaslowski/mood-tracker:latest
 
 For more guidance on Docker networking, please refer to the [official documentation](https://docs.docker.com/network/).
 
@@ -116,7 +116,7 @@ docker run -d --rm \
   --name mood-tracker \
   -e TELEGRAM_TOKEN="$TELEGRAM_TOKEN" \
   -v "$HOME/.aws/credentials:/root/.aws/credentials:ro" \
-  public.ecr.aws/c1o1h8f4/mood-tracker:latest
+  tobiaswaslowski/mood-tracker:latest
 ```
 
 Why `/root/.aws/credentials`? Because `boto3` checks in the home directory of the user running the script for the
@@ -134,7 +134,7 @@ docker run -d --rm \
   --name mood-tracker \
   -e TELEGRAM_TOKEN="$TELEGRAM_TOKEN" \
   -v ./config.yaml:/app/config.yaml \
-  public.ecr.aws/c1o1h8f4/mood-tracker:latest
+  tobiaswaslowski/mood-tracker:latest
   ```
 
 # Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - mongo_data:/data/db
 
   mood-tracker:
-    image: public.ecr.aws/c1o1h8f4/mood-tracker:latest
+    image: tobiaswaslowski/mood-tracker:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,4 +18,4 @@ sudo docker run -d --rm \
   --security-opt seccomp:unconfined \
   -v "$HOME/.aws/credentials:/root/.aws/credentials:ro" \
   -v ./config.yaml:/app/config.yaml \
-  public.ecr.aws/c1o1h8f4/mood-tracker:latest
+  tobiaswaslowski/mood-tracker:latest

--- a/terraform/files/USAGE.md
+++ b/terraform/files/USAGE.md
@@ -1,28 +1,19 @@
 # Usage
 
+## DEPRECATION NOTICE
+
+I'm discontinuing support for ECR. Please use the Docker Hub image instead. The new repository is:
+
+    tobiaswaslowski/mood-tracker
+
 ## Quickstart
 
-I host the Docker image for this application on a public ECR repository. You have to create your own
-Telegram via the [Botfather](https://t.me/botfather) and supply it to the container as an environment variable.
+You have to create your ownm Telegram via the [Botfather](https://t.me/botfather) and supply it to the container as an environment variable.
 Additionally, you'll have to have a MongoDB instance running for persistence.
 Assuming you have a MongoDB instance running on your local machine that is bound to `127.0.0.1:27017`,
 (e.g. by running `docker run -p 27017:27017 mongo`) you can run the following command:
 
     docker run --env TELEGRAM_TOKEN=$TELEGRAM_TOKEN \
-      public.ecr.aws/c1o1h8f4/mood-tracker:latest
+      tobiaswaslowski/mood-tracker:latest
 
-Supported architectures are x86_64 (amd64) and arm64. If you require images
-for additional architectures, feel free to raise a ticket or build your own images (see [Development](#development)).
-
-## MongoDB Configuration
-
-If your MongoDB instance is bound to a different hosts, you'll have to supply the connection string as an environment
-variable. If you're running Docker for Linux, I recommend using `--network="host"` for simplicity's sake.
-The run command in that case could look like this:
-
-    docker run --env TELEGRAM_TOKEN=$TELEGRAM_TOKEN \
-        --env MONGO_HOST=192.168.1.1:27017 \
-        --network="host" \
-          public.ecr.aws/c1o1h8f4/mood-tracker:latest
-
-For more guidance on Docker networking, please refer to the [official documentation](https://docs.docker.com/network/).
+DynamoDB is also supported as a backend. For more information, check out the [documentation](https://github.com/twaslowski/telegram-mood-tracker?tab=readme-ov-file#running).


### PR DESCRIPTION
Hosting the image in the Dockerhub registry is going to be much simpler and cost-effective than doing it on AWS ECR.